### PR TITLE
Checking to see if the uriKey method exists before filtering for it.

### DIFF
--- a/src/Http/Controllers/ResourceController.php
+++ b/src/Http/Controllers/ResourceController.php
@@ -14,6 +14,10 @@ class ResourceController extends Controller
 
         $card = collect(Nova::$cards)
             ->filter(function ($card) use ($key) {
+                if(! method_exists($card, 'uriKey')) {
+                    return false;
+                }
+
                 return $card->uriKey() == $key;
             })->first();
 


### PR DESCRIPTION
If a card doesn't have a uriKey, even if the card isn't being used, it was breaking the list cards everywhere. This will make it so that cards with no uriKey method are simply skipped when being filtered.